### PR TITLE
Removing filtered dat files and adding SHMS pruning

### DIFF
--- a/PARAM/SHMS/GEN/ptracking_sp18.param
+++ b/PARAM/SHMS/GEN/ptracking_sp18.param
@@ -39,7 +39,7 @@ pntracks_max_fp = 10
 ; psel_using_scin         uses scintillator for track selection
   psel_using_scin = 0
 ; psel_using_prune         using prune
-  psel_using_prune = 0
+  psel_using_prune = 1
 
 ; parameters used in selecting tracks for Hodoscope efficiency in THcHodoEff.cxx
 ;   HodoEff_CalEnergy_Cut  cut on the track energy (GeV)

--- a/SCRIPTS/HMS/PRODUCTION/replay_production_hms.C
+++ b/SCRIPTS/HMS/PRODUCTION/replay_production_hms.C
@@ -17,10 +17,7 @@ void replay_production_hms(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Create file name patterns.
   const char* RunFileNamePattern;
-  if (RunNumber == 1566 || RunNumber == 1598 || RunNumber == 1608 || RunNumber == 1618)
-    RunFileNamePattern = "hms_all_%05d_filtered.dat";
-  else 
-    RunFileNamePattern = "hms_all_%05d.dat";
+  RunFileNamePattern = "hms_all_%05d.dat";
   vector<TString> pathList;
   pathList.push_back(".");
   pathList.push_back("./raw");


### PR DESCRIPTION
Merging commits that remove the hms filtered dat files from being searched for by the replay script and that change the pruning method on from 0 to 1 for the SHMS